### PR TITLE
Add multi-server CRCON support

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -5,8 +5,6 @@ import cron from 'node-cron';
 
 dotenv.config();
 
-const API_BASE_URL = process.env.RCON_API_BASE_URL;
-const API_TOKEN = process.env.RCON_API_TOKEN;
 const DISCORD_TOKEN = process.env.DISCORD_TOKEN;
 const DISCORD_CHANNEL_ID = process.env.DISCORD_CHANNEL_ID;
 const RESTART_TIME = process.env.RESTART_TIME || '04:00'; // Default to 4 AM if not specified
@@ -36,19 +34,43 @@ const roleTranslations = {
 
 const rankEmojis = ['🥇', '🥈', '🥉'];
 
-async function getPlayerData() {
-    const url = `${API_BASE_URL}/api/get_detailed_players`;
+function getServersFromEnv() {
+    let servers = [];
     try {
+        Object.entries(process.env).forEach((env) => {
+            if (env[0].includes('RCON_API_SERVER_NAME_')) {
+                let number = env[0].match(/\d+$/);
+                servers.push({
+                    name: process.env['RCON_API_SERVER_NAME_' + number],
+                    baseUrl: process.env['RCON_API_BASE_URL_' + number],
+                    token: process.env['RCON_API_TOKEN_' + number]
+                });
+            }
+        });
+        if (servers.length == 0) {
+            console.error('No servers defined in environment variables.  Please refer to README.md for variable configuration.');
+            process.exit(1);
+        };
+    } catch (error) {
+        console.warn('Failed to parse server data from environment variables:', error)
+    }
+    return servers;
+}
+
+async function getPlayerDataFromServer(server) {
+    const url = `${server.baseUrl}/api/get_detailed_players`;
+    try {
+        console.log(`Updating player data from \"${server.name} - ${server.baseUrl}\"`)
         const response = await fetch(url, {
             headers: {
-                'Authorization': `Bearer ${API_TOKEN}`
+                'Authorization': `Bearer ${server.token}`
             }
         });
         if (response.status !== 200) {
-            throw new Error(`Failed to fetch data: ${response.statusText}`);
+            throw new Error(`Failed to fetch data from ${server.name}: ${response.statusText}`);
         }
         const data = await response.json();
-        console.log('API response:', data);
+        console.log('API response from ${server.name}:', data);
 
         if (data.result && data.result.players && typeof data.result.players === 'object') {
             return Object.values(data.result.players)
@@ -58,7 +80,7 @@ async function getPlayerData() {
                         return false;
                     }
                     if (!player.kills || !player.name || !player.role) {
-                        console.warn('Skipping player with missing data:', player);
+                        console.warn(`Skipping player with missing data from ${server.name}:`, player);
                         return false;
                     }
                     return player.kills > 0;
@@ -67,27 +89,38 @@ async function getPlayerData() {
                     name: player.name,
                     steam_id_64: player.steam_id_64,
                     kills: player.kills,
-                    role: roleTranslations[player.role] || player.role
+                    role: roleTranslations[player.role] || player.role,
+                    server: server.name
                 }));
         } else {
             console.warn('Unexpected response format or no valid player data');
             return [];
         }
     } catch (error) {
-        console.error('Error fetching player data:', error);
+        console.error('Error fetching player data from ${server.name}:', error);
+        return [];
+    }
+}
+
+async function getAllPlayerData(servers) {
+    try {
+        const allPlayerData = await Promise.all(servers.map(getPlayerDataFromServer));
+        return allPlayerData.flat();
+    } catch (error) {
+        console.error('Error fetching data from all servers', error);
         return [];
     }
 }
 
 function updateKillData(players) {
     players.forEach(player => {
-        const { name, kills, role } = player;
+        const { name, kills, role, server } = player;
         if (playerKills[name]) {
             if (kills > playerKills[name].kills) {
-                playerKills[name] = { kills, role };
+                playerKills[name] = { kills, role, server };
             }
         } else {
-            playerKills[name] = { kills, role };
+            playerKills[name] = { kills, role, server };
         }
     });
 }
@@ -96,11 +129,11 @@ function getTop20Players() {
     return Object.entries(playerKills)
         .sort(([, { kills: killsA }], [, { kills: killsB }]) => killsB - killsA)
         .slice(0, 20)
-        .map(([name, { kills, role }], index) => ({ index: index + 1, name, kills, role }));
+        .map(([name, { kills, role, server }], index) => ({ index: index + 1, name, kills, role, server }));
 }
 
-function truncatePlayerNameRole(name, role, maxLength) {
-    const combined = `${name} (${role})`;
+function truncatePlayerNameRole(name, role, server, maxLength) {
+    const combined = `${name} (${role}) - ${server}`;
     if (combined.length > maxLength) {
         return combined.slice(0, maxLength - 3) + '...';
     }
@@ -110,7 +143,7 @@ function truncatePlayerNameRole(name, role, maxLength) {
 async function sendToDiscord(topPlayers) {
     const embed = new EmbedBuilder()
         .setColor('#0099ff')
-        .setTitle('Top 20 Players with the highest kill count')
+        .setTitle('Top 20 Players with the highest kill count (All Servers)')
         .setThumbnail('https://imgur.com/cYkTFeF.png')
         .setFooter({ text: 'Last Refresh', iconURL: 'https://i.imgur.com/9Iaiwje.png' })
         .setTimestamp();
@@ -118,9 +151,9 @@ async function sendToDiscord(topPlayers) {
     if (topPlayers.length > 0) {
         const description = topPlayers.map(player => {
             let rankIndicator = player.index <= 3 ? rankEmojis[player.index - 1] : `${player.index}.`;
-            let playerEntry = `${rankIndicator} ${player.kills} - ${truncatePlayerNameRole(player.name, player.role, 44)}`;
+            let playerEntry = `${rankIndicator} ${player.kills} - ${truncatePlayerNameRole(player.name, player.role, player.server, 44)}`;
             if (player.index <= 3) {
-                playerEntry = `**${playerEntry}**`;
+                playerEntry = `${playerEntry}`;
             }
             return playerEntry;
         }).join('\n');
@@ -159,7 +192,8 @@ async function sendToDiscord(topPlayers) {
 
 async function main() {
     try {
-        const players = await getPlayerData();
+        const servers = getServersFromEnv();
+        const players = await getAllPlayerData(servers);
         updateKillData(players);
         const topPlayers = getTop20Players();
         await sendToDiscord(topPlayers);


### PR DESCRIPTION
Support multiple servers by appending `_X` to their respective fields, where `X` is a number.  For example:
```
RCON_SERVER_NAME_1=your_server_name
RCON_API_BASE_URL_1=your_api_base_url
RCON_API_TOKEN_1=your_api_token

RCON_SERVER_NAME_2=your_server_name
RCON_API_BASE_URL_2=your_api_base_url
RCON_API_TOKEN_2=your_api_token
```
This does require users to update their single server setups to append `_1` to the end of these fields.