### PR TITLE
Print skipped message only on undefined kills, not zero

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -57,7 +57,7 @@ async function getPlayerData() {
                         console.warn('Skipping invalid player object:', player);
                         return false;
                     }
-                    if (!player.kills || !player.name || !player.role) {
+                    if (player.kills === undefined || !player.name || !player.role) {
                         console.warn('Skipping player with missing data:', player);
                         return false;
                     }


### PR DESCRIPTION
Currently, any player with zero kills will cause the "skipped player" message to print.  We only want this to print if kills is undefined in the API output.